### PR TITLE
Feat: 마우스 엣지 스크롤링 기능 구현 및 카메라 이동 로직 리팩토링

### DIFF
--- a/Source/NovaRevolution/Core/NovaPlayerState.cpp
+++ b/Source/NovaRevolution/Core/NovaPlayerState.cpp
@@ -36,7 +36,7 @@ void ANovaPlayerState::BeginPlay()
 				if (FMath::FloorToInt(Data.OldValue) != FMath::FloorToInt(Data.NewValue))
 				{
 					OnWattChanged.Broadcast(Data.NewValue, GetMaxWatt());
-					NOVA_SCREEN(Log, "Watt Changed: %.0f / %.0f", Data.NewValue, GetMaxWatt());
+					// NOVA_SCREEN(Log, "Watt Changed: %.0f / %.0f", Data.NewValue, GetMaxWatt());
 				}
 			}
 		);
@@ -49,7 +49,7 @@ void ANovaPlayerState::BeginPlay()
 				if (FMath::FloorToInt(Data.OldValue) != FMath::FloorToInt(Data.NewValue))
 				{
 					OnSPChanged.Broadcast(Data.NewValue, GetMaxSP());
-					NOVA_SCREEN(Log, "SP Changed: %.1f / %.1f", Data.NewValue, GetMaxSP());
+					// NOVA_SCREEN(Log, "SP Changed: %.1f / %.1f", Data.NewValue, GetMaxSP());
 				}
 			}
 		);
@@ -59,7 +59,7 @@ void ANovaPlayerState::BeginPlay()
 			[this](const FOnAttributeChangeData& Data)
 			{
 				OnPopulationChanged.Broadcast(Data.NewValue, GetMaxPopulation());
-				NOVA_SCREEN(Log, "Population Changed: %.0f / %.0f", Data.NewValue, GetMaxPopulation());
+				// NOVA_SCREEN(Log, "Population Changed: %.0f / %.0f", Data.NewValue, GetMaxPopulation());
 			}
 		);
 
@@ -68,7 +68,7 @@ void ANovaPlayerState::BeginPlay()
 			[this](const FOnAttributeChangeData& Data)
 			{
 				OnWattLevelChanged.Broadcast(Data.NewValue, 0.0f);
-				NOVA_SCREEN(Warning, "Watt Production Level Up: %.0f", Data.NewValue);
+				// NOVA_SCREEN(Warning, "Watt Production Level Up: %.0f", Data.NewValue);
 			}
 		);
 
@@ -77,7 +77,7 @@ void ANovaPlayerState::BeginPlay()
 			[this](const FOnAttributeChangeData& Data)
 			{
 				OnSPLevelChanged.Broadcast(Data.NewValue, 0.0f);
-				NOVA_SCREEN(Warning, "SP Production Level Up: %.0f", Data.NewValue);
+				// NOVA_SCREEN(Warning, "SP Production Level Up: %.0f", Data.NewValue);
 			}
 		);
 	}

--- a/Source/NovaRevolution/Player/NovaPlayerController.cpp
+++ b/Source/NovaRevolution/Player/NovaPlayerController.cpp
@@ -22,13 +22,26 @@ ANovaPlayerController::ANovaPlayerController()
 void ANovaPlayerController::BeginPlay()
 {
 	Super::BeginPlay();
-	
+
+	// 입력 모드 설정 (Game : 게임 월드 입력(클릭, 드래그) 지원 | UI : UI 마우스 오버 등 지원)
+	FInputModeGameAndUI InputMode;
+
+	// 마우스 가두기 옵션 설정 (LcokAlways 또는 LockInFullScreen)
+	InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::LockAlways);
+
+	// 커서 표시 설정
+	InputMode.SetHideCursorDuringCapture(false);;
+
+	// 컨트롤러에 적용
+	SetInputMode(InputMode);
+
 	// 1. 로컬 플레이어(내 화면)인지 확인 (UI 생성 및 입력 설정의 필수 조건)
 	if (IsLocalPlayerController())
 	{
 		// 기존 코드 내부로 이동
 		// Local Player Subsystem 가져오기
-		if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(
+		if (UEnhancedInputLocalPlayerSubsystem* Subsystem = ULocalPlayer::GetSubsystem<
+			UEnhancedInputLocalPlayerSubsystem>(
 			GetLocalPlayer()))
 		{
 			// IMC가 에디터에서 할당되었는지 확인 후 추가
@@ -38,7 +51,7 @@ void ANovaPlayerController::BeginPlay()
 				Subsystem->AddMappingContext(IMC, 0);
 			}
 		}
-		
+
 		// --- 새로운 로직: 메인 HUD 생성 및 표시 ---
 		// 에디터(BP_NovaPlayerController)에서 MainHUDClass가 할당되었는지 확인
 		if (MainHUDClass)
@@ -50,7 +63,6 @@ void ANovaPlayerController::BeginPlay()
 			}
 		}
 	}
-	
 }
 
 void ANovaPlayerController::SetupInputComponent()
@@ -70,6 +82,53 @@ void ANovaPlayerController::SetupInputComponent()
 	{
 		NovaInputComponent->BindAction(MoveCameraAction, ETriggerEvent::Triggered, this,
 		                               &ANovaPlayerController::MoveCamera);
+	}
+}
+
+void ANovaPlayerController::PlayerTick(float DeltaTime)
+{
+	Super::PlayerTick(DeltaTime);
+
+	// 마우스 스크롤링 기능
+	if (bEnableEdgeScrolling)
+	{
+		float MouseX, MouseY;
+		// 마우스 좌표 얻어오기(APlayerController 함수)
+		if (GetMousePosition(MouseX, MouseY))
+		{
+			int32 ViewportSizeX, ViewportSizeY;
+			// Viewport 사이즈 얻어오기(APlayerController 함수)
+			GetViewportSize(ViewportSizeX, ViewportSizeY);
+
+			float ForwardInput = 0.f;
+			float RightInput = 0.f;
+
+			// 상단/하단 경계 체크 (Y축은 위쪽이 0)
+			if (MouseY <= EdgeScrollMargin)
+			{
+				ForwardInput = 1.f;
+			}
+			else if (MouseY >= ViewportSizeY - EdgeScrollMargin)
+			{
+				ForwardInput = -1.f;
+			}
+
+			// 좌측/우측 경계 체크
+			if (MouseX <= EdgeScrollMargin)
+			{
+				RightInput = -1.f;
+			}
+			else if (MouseX >= ViewportSizeX - EdgeScrollMargin)
+			{
+				RightInput = 1.f;
+			}
+			
+			// 마우스가 경계이 있다면 카메라 이동 적용
+			if (ForwardInput != 0.f || RightInput != 0.f)
+			{
+				ApplyCameraMovement(ForwardInput, RightInput);
+			}
+		}
 	}
 }
 
@@ -128,7 +187,7 @@ void ANovaPlayerController::Input_AbilityInputTagReleased(FGameplayTag InputTag)
 		{
 			NovaHUD->UpdateDragRect(FVector2D::ZeroVector, FVector2D::ZeroVector, false);
 		}
-		
+
 		if (bIsDraggingBox)
 		{
 			// 드래그 선택 수행
@@ -201,24 +260,29 @@ void ANovaPlayerController::MoveCamera(const FInputActionValue& Value)
 {
 	// 입력 값 가져오기
 	FVector2D InputVector = Value.Get<FVector2D>();
+	
+	// 공통 함수로 입력을 넘김. (Y는 Forward, X는 Right)
+	ApplyCameraMovement(InputVector.Y, InputVector.X);
+}
 
-	// 조종 중인 Pawn 가져오기
+void ANovaPlayerController::ApplyCameraMovement(float ForwardInput, float RightInput)
+{
 	APawn* ControlledPawn = GetPawn();
-
-	if (ControlledPawn && (InputVector.SizeSquared() > 0.f))
+	
+	if (ControlledPawn)
 	{
 		// 카메라의 현재 회전 방향을 기준으로 앞/옆 방향 계산
 		const FRotator Rotation = GetControlRotation();
 		const FRotator YawRotation(0.f, Rotation.Yaw, 0.f);
-
+		
 		// 앞/뒤 이동 벡터 계산
 		const FVector ForwardDirection = FRotationMatrix(YawRotation).GetUnitAxis(EAxis::X);
 		// 좌/우 이동 벡터 계산
 		const FVector RightDirection = FRotationMatrix(YawRotation).GetUnitAxis(EAxis::Y);
 
 		// Pawn에게 이동 명령 전달 (속도는 Pawn의 MovementComponent에서 조절)
-		ControlledPawn->AddMovementInput(ForwardDirection, InputVector.Y);
-		ControlledPawn->AddMovementInput(RightDirection, InputVector.X);
+		ControlledPawn->AddMovementInput(ForwardDirection, ForwardInput);
+		ControlledPawn->AddMovementInput(RightDirection, RightInput);
 	}
 }
 

--- a/Source/NovaRevolution/Player/NovaPlayerController.h
+++ b/Source/NovaRevolution/Player/NovaPlayerController.h
@@ -28,11 +28,22 @@ protected:
 	// 커스텀 입력 컴포넌트를 사용하기 위해 오버라이드 합니다.
 	virtual void SetupInputComponent() override;
 
+	// 매 프레임 마우스 엣지 체크를 위해 오버라이드
+	virtual void PlayerTick(float DeltaTime) override;
+	
 	// 현재 드래그 상태인지 여부
 	bool bIsDraggingBox = false;
 	
 	// 현재 Shift(다중 선택) 모드인지 여부
 	bool bIsShiftDown = false;
+	
+	// 엣지 스크롤링 활성화 여부
+	UPROPERTY(EditDefaultsOnly, Category = "Nova|Input")
+	bool bEnableEdgeScrolling = true;
+	
+	// 화면 끝에서 몇 픽셀 이내일 때 화면을 이동시킬지 설정
+	UPROPERTY(EditDefaultsOnly, Category = "Nova|Input")
+	float EdgeScrollMargin = 15.f;
 	
 	// 에디터에서 할당할 IMC
 	UPROPERTY(EditDefaultsOnly, Category = "Nova|Input")
@@ -63,9 +74,12 @@ protected:
 	// 마우스 Held
 	void Input_AbilityInputTagHeld(FGameplayTag InputTag);
 
-	// 실제 카메라 이동 처리 함수
+	// 실제 카메라 이동 처리 함수 -> 마우스 스크롤링 추가되어 공용 함수 ApplyCameraMovement이용
 	void MoveCamera(const FInputActionValue& Value);
 
+	// 공통 카메라 이동처리 함수 (키보드와 마우스 엣지에서 공용으로 사용)
+	void ApplyCameraMovement(float ForwardInput, float RightInput);
+	
 	// 드래그 선택을 수행하는 실제 판정 함수
 	void PerformBoxSelection();
 	


### PR DESCRIPTION
## 📝 작업 상세

### ✨ Feat (새로운 기능)
**Player**
  - Camera Control
    - PlayerTick 오버라이드를 통한 실시간 마우스 위치 감시 및 엣지 스크롤링 기능 추가
    - bEnableEdgeScrolling, EdgeScrollMargin 변수를 활용한 설정 제어 지원
  
### ♻️ Refactor (코드 리팩토링)
**Player**
  - NovaPlayerController
    - ApplyCameraMovement 함수를 신설하여 카메라 이동 로직(방향 계산 및 입력 전달)을 공통화
    - 기존 Enhanced Input 콜백(MoveCamera)과 PlayerTick의 엣지 스크롤 로직이 동일한 이동 함수를 공유하도록 구조 개선

### ❓ 질문 및 검토 사항
- 현재 EdgeScrollMargin의 기본값은 15.f입니다. 실제 플레이 시 체감이 어떤지 확인이 필요합니다.
- 현재 카메라 이동 속도를 별도로 조절하지 않았습니다. 실제 플레이 시 체감이 어떤지 확인이 필요합니다.
