### PR TITLE
Fix: NovaBase PlayerState 등록 로직 개선

### DIFF
--- a/Source/NovaRevolution/Core/NovaBase.cpp
+++ b/Source/NovaRevolution/Core/NovaBase.cpp
@@ -47,14 +47,30 @@ void ANovaBase::BeginPlay()
 		AbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(AttributeSet->GetHealthAttribute())
 			.AddUObject(this, &ANovaBase::OnHealthChanged);
 	}
+}
 
-	// PlayerState에 자신을 플레이어의 기지로 등록
-	if (APlayerController* PC = GetNetOwningPlayer() ? GetNetOwningPlayer()->GetPlayerController(GetWorld()) : nullptr)
+void ANovaBase::SetTeamID(int32 NewTeamID)
+{
+	TeamID = NewTeamID;
+
+	// 해당 팀의 PlayerState를 찾아 자신을 등록
+	UWorld* World = GetWorld();
+	if (!World) return;
+
+	// 월드 내의 모든 PlayerState를 검색하여 TeamID가 일치하는 것을 찾음
+	TArray<AActor*> FoundPlayerStates;
+	UGameplayStatics::GetAllActorsOfClass(World, ANovaPlayerState::StaticClass(), FoundPlayerStates);
+
+	for (AActor* Actor : FoundPlayerStates)
 	{
-		if (ANovaPlayerState* PS = PC->GetPlayerState<ANovaPlayerState>())
+		if (ANovaPlayerState* PS = Cast<ANovaPlayerState>(Actor))
 		{
-			PS->SetPlayerBase(this);
-			NOVA_LOG(Log, "Base '%s' registered to PlayerState of '%s'", *GetName(), *PS->GetPlayerName());
+			if (PS->GetTeamID() == TeamID)
+			{
+				PS->SetPlayerBase(this);
+				NOVA_LOG(Log, "Base '%s' registered to PlayerState of team %d", *GetName(), TeamID);
+				return;
+			}
 		}
 	}
 }

--- a/Source/NovaRevolution/Core/NovaBase.h
+++ b/Source/NovaRevolution/Core/NovaBase.h
@@ -41,7 +41,7 @@ public:
 
 	/** 팀 ID를 설정합니다. (GameMode에서 호출) */
 	UFUNCTION(BlueprintCallable, Category = "Nova|Team")
-	void SetTeamID(int32 NewTeamID) { TeamID = NewTeamID; }
+	void SetTeamID(int32 NewTeamID);
 
 	// --- INovaProductionInterface ---
 	UFUNCTION(BlueprintCallable, Category = "Nova|Production")


### PR DESCRIPTION
## 📌 작업 개요
- NovaBase가 PlayerState를 찾아 자신을 등록하는 과정에서 발생하던 불안정성 해결 및 로직 개선

## 📝 작업 상세

### 🐛 Fix (버그 수정)
**Core**
  - NovaBase
    - `BeginPlay`에서 `GetNetOwningPlayer()`를 통해 `PlayerState`를 등록하던 기존의 불안정한 로직 제거
    - `SetTeamID` 호출 시점에 월드 내 모든 `PlayerState`를 검색하여 `TeamID`가 일치하는 `PlayerState`에 자신을 등록하도록 개선