### PR TITLE
[Fix] 기지 파괴 및 유닛 사망 시 자원 관리/UI 동기화 버그 수정

### DIFF
--- a/Source/NovaRevolution/Core/NovaBase.cpp
+++ b/Source/NovaRevolution/Core/NovaBase.cpp
@@ -179,6 +179,30 @@ void ANovaBase::DestroyBase()
 	// 기지 파괴 시 시각적/게임 로직 처리
 	UE_LOG(LogTemp, Error, TEXT("Base Destroyed: %s (TeamID: %d)"), *GetName(), TeamID);
 
+	// 자원 재생 중단 (해당 팀의 PlayerState를 찾아 ResourceComponent 접근)
+	UWorld* World = GetWorld();
+	if (World)
+	{
+		for (FConstPlayerControllerIterator Iterator = World->GetPlayerControllerIterator(); Iterator; ++Iterator)
+		{
+			if (APlayerController* PC = Iterator->Get())
+			{
+				if (ANovaPlayerState* PS = PC->GetPlayerState<ANovaPlayerState>())
+				{
+					// INovaTeamInterface를 통해 팀 ID를 확인합니다.
+					INovaTeamInterface* TeamInterface = Cast<INovaTeamInterface>(PS);
+					if (TeamInterface && TeamInterface->GetTeamID() == TeamID)
+					{
+						if (UNovaResourceComponent* ResourceComp = PS->FindComponentByClass<UNovaResourceComponent>())
+						{
+							ResourceComp->StopResourceRegen();
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// PlayerState에서 기지 참조 해제
 	if (APlayerController* PC = GetNetOwningPlayer() ? GetNetOwningPlayer()->GetPlayerController(GetWorld()) : nullptr)
 	{

--- a/Source/NovaRevolution/Core/NovaInterfaces.h
+++ b/Source/NovaRevolution/Core/NovaInterfaces.h
@@ -121,6 +121,7 @@ public:
 	virtual FNovaOnResourceChangedSignature& GetOnWattChangedDelegate() = 0;
 	virtual FNovaOnResourceChangedSignature& GetOnSPChangedDelegate() = 0;
 	virtual FNovaOnResourceChangedSignature& GetOnPopulationChangedDelegate() = 0;
+	virtual FNovaOnResourceChangedSignature& GetOnTotalUnitWattChangedDelegate() = 0;
 	virtual FNovaOnResourceChangedSignature& GetOnWattLevelChangedDelegate() = 0;
 	virtual FNovaOnResourceChangedSignature& GetOnSPLevelChangedDelegate() = 0;
 };

--- a/Source/NovaRevolution/Core/NovaPlayerState.cpp
+++ b/Source/NovaRevolution/Core/NovaPlayerState.cpp
@@ -61,6 +61,14 @@ void ANovaPlayerState::BeginPlay()
 			}
 		);
 
+		// TotalUnitWatt 변경 감지
+		AbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(ResourceAttributeSet->GetTotalUnitWattAttribute()).AddLambda(
+			[this](const FOnAttributeChangeData& Data)
+			{
+				OnTotalUnitWattChanged.Broadcast(Data.NewValue, GetMaxUnitWatt());
+			}
+		);
+
 		// Watt Level 변경 감지
 		AbilitySystemComponent->GetGameplayAttributeValueChangeDelegate(ResourceAttributeSet->GetWattLevelAttribute()).AddLambda(
 			[this](const FOnAttributeChangeData& Data)

--- a/Source/NovaRevolution/Core/NovaPlayerState.h
+++ b/Source/NovaRevolution/Core/NovaPlayerState.h
@@ -68,6 +68,7 @@ public:
 	virtual FNovaOnResourceChangedSignature& GetOnWattChangedDelegate() override { return OnWattChanged; }
 	virtual FNovaOnResourceChangedSignature& GetOnSPChangedDelegate() override { return OnSPChanged; }
 	virtual FNovaOnResourceChangedSignature& GetOnPopulationChangedDelegate() override { return OnPopulationChanged; }
+	virtual FNovaOnResourceChangedSignature& GetOnTotalUnitWattChangedDelegate() override { return OnTotalUnitWattChanged; }
 	virtual FNovaOnResourceChangedSignature& GetOnWattLevelChangedDelegate() override { return OnWattLevelChanged; }
 	virtual FNovaOnResourceChangedSignature& GetOnSPLevelChangedDelegate() override { return OnSPLevelChanged; }
 
@@ -88,6 +89,9 @@ public:
 	
 	UPROPERTY(BlueprintAssignable, Category = "Nova|Resource")
 	FNovaOnResourceChangedSignature OnPopulationChanged;
+	
+	UPROPERTY(BlueprintAssignable, Category = "Nova|Resource")
+	FNovaOnResourceChangedSignature OnTotalUnitWattChanged;
 	
 	UPROPERTY(BlueprintAssignable, Category = "Nova|Resource")
 	FNovaOnResourceChangedSignature OnWattLevelChanged;

--- a/Source/NovaRevolution/Core/NovaResourceComponent.cpp
+++ b/Source/NovaRevolution/Core/NovaResourceComponent.cpp
@@ -6,6 +6,8 @@
 #include "GAS/NovaGameplayTags.h"
 #include "AbilitySystemComponent.h"
 #include "GameplayEffectTypes.h"
+#include "NovaLog.h"
+#include "NovaRevolution.h"
 
 UNovaResourceComponent::UNovaResourceComponent()
 {
@@ -93,4 +95,18 @@ void UNovaResourceComponent::UpdatePopulation(float DeltaPopulation, float Delta
     // 이 부분도 GE를 활용하고자 한다면 ConsumeResources와 유사하게 구현 가능
     ResourceAttributeSet->SetCurrentPopulation(ResourceAttributeSet->GetCurrentPopulation() + DeltaPopulation);
     ResourceAttributeSet->SetTotalUnitWatt(ResourceAttributeSet->GetTotalUnitWatt() + DeltaWatt);
+}
+
+void UNovaResourceComponent::StopResourceRegen()
+{
+	if (RegenEffectHandle.IsValid())
+	{
+		UAbilitySystemComponent* ASC = OwnerPlayerState ? OwnerPlayerState->GetAbilitySystemComponent() : nullptr;
+		if (ASC)
+		{
+			ASC->RemoveActiveGameplayEffect(RegenEffectHandle);
+			RegenEffectHandle.Invalidate();
+			NOVA_LOG(Log, "Resource regeneration stopped for PlayerState: %s", *OwnerPlayerState->GetName());
+		}
+	}
 }

--- a/Source/NovaRevolution/Core/NovaResourceComponent.h
+++ b/Source/NovaRevolution/Core/NovaResourceComponent.h
@@ -40,6 +40,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Nova|Resource")
 	void UpdatePopulation(float DeltaPopulation, float DeltaWatt);
 
+	/** 자원 회복 GE를 중단합니다. (기지 파괴 시 등) */
+	UFUNCTION(BlueprintCallable, Category = "Nova|Resource")
+	void StopResourceRegen();
+
 	/** 자원 회복용 GameplayEffect 클래스 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Nova|Resource")
 	TSubclassOf<class UGameplayEffect> RegenGameplayEffectClass;

--- a/Source/NovaRevolution/Core/NovaUnit.cpp
+++ b/Source/NovaRevolution/Core/NovaUnit.cpp
@@ -3,16 +3,16 @@
 #include "Core/NovaUnit.h"
 #include "Core/NovaPart.h"
 #include "Core/NovaPartData.h"
+#include "Core/NovaResourceComponent.h"
 #include "AbilitySystemComponent.h"
 #include "AttributeSet.h"
 #include "NovaRevolution.h"
-#include "GAS/NovaAttributeSet.h"
+#include "NovaPlayerState.h"
+#include "BehaviorTree/BlackboardComponent.h"
+#include "Core/AI/NovaAIController.h"
 #include "Components/CapsuleComponent.h"
 #include "GameFramework/CharacterMovementComponent.h"
-#include "Core/AI/NovaAIController.h"
-#include "BehaviorTree/BlackboardComponent.h"
-#include "Core/NovaLog.h"
-#include "DSP/AudioDebuggingUtilities.h"
+#include "GAS/NovaAttributeSet.h"
 #include "GAS/Abilities/NovaGameplayAbility.h"
 
 ANovaUnit::ANovaUnit()
@@ -525,6 +525,37 @@ void ANovaUnit::Die()
 	// 유닛 사망 처리 로직
 	NOVA_LOG(Warning, "Unit Died: %s", *GetName());
 	bIsDead = true;
+
+	// 자원 반납 (인구수 -1, 자신의 와트 비용만큼 차감)
+	if (UAbilitySystemComponent* ASC = GetAbilitySystemComponent())
+	{
+		float UnitWatt = ASC->GetNumericAttribute(UNovaAttributeSet::GetWattAttribute());
+		
+		UWorld* World = GetWorld();
+		if (World)
+		{
+			for (FConstPlayerControllerIterator Iterator = World->GetPlayerControllerIterator(); Iterator; ++Iterator)
+			{
+				if (APlayerController* PC = Iterator->Get())
+				{
+					if (ANovaPlayerState* PS = PC->GetPlayerState<ANovaPlayerState>())
+					{
+						// INovaTeamInterface를 통해 팀 ID를 확인합니다.
+						INovaTeamInterface* TeamInterface = Cast<INovaTeamInterface>(PS);
+						if (TeamInterface && TeamInterface->GetTeamID() == TeamID)
+						{
+							if (UNovaResourceComponent* ResourceComp = PS->FindComponentByClass<UNovaResourceComponent>())
+							{
+								ResourceComp->UpdatePopulation(-1.0f, -UnitWatt);
+								NOVA_LOG(Log, "Unit %s (Watt: %.f) died. Resources returned to team %d", *GetName(), UnitWatt, TeamID);
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
 	// AI 동작 정지 요청
 	if (ANovaAIController* AIC = Cast<ANovaAIController>(GetController()))

--- a/Source/NovaRevolution/UI/NovaResourceWidget.cpp
+++ b/Source/NovaRevolution/UI/NovaResourceWidget.cpp
@@ -19,16 +19,13 @@ void UNovaResourceWidget::NativeConstruct()
             PS->OnWattChanged.AddDynamic(this, &UNovaResourceWidget::UpdateWattUI);
             PS->OnSPChanged.AddDynamic(this, &UNovaResourceWidget::UpdateSPUI);
             PS->OnPopulationChanged.AddDynamic(this, &UNovaResourceWidget::UpdatePopulationUI);
+            PS->OnTotalUnitWattChanged.AddDynamic(this, &UNovaResourceWidget::UpdateUnitWattUI);
 
             // 2. 초기값 동기화 (게임 시작 시 현재 자원 상태 반영)
             UpdateWattUI(PS->GetCurrentWatt(), PS->GetMaxWatt());
             UpdateSPUI(PS->GetCurrentSP(), PS->GetMaxSP());
             UpdatePopulationUI(PS->GetCurrentPopulation(), PS->GetMaxPopulation());
-
-            // UnitWatt는 별도 델리게이트가 없다면 초기화 시 직접 설정
-            SetResourceText(Text_UnitWatt, PS->GetTotalUnitWatt(), PS->GetMaxUnitWatt());
-            if (ProgressBar_UnitWatt && PS->GetMaxUnitWatt() > 0)
-                ProgressBar_UnitWatt->SetPercent(PS->GetTotalUnitWatt() / PS->GetMaxUnitWatt());
+            UpdateUnitWattUI(PS->GetTotalUnitWatt(), PS->GetMaxUnitWatt());
         }
     }
 }
@@ -49,14 +46,12 @@ void UNovaResourceWidget::UpdatePopulationUI(float Current, float Max)
 {
     if (ProgressBar_Population && Max > 0) ProgressBar_Population->SetPercent(Current / Max);
     SetResourceText(Text_Population, Current, Max);
+}
 
-    // 인구수가 변할 때 유닛 와트 총합도 같이 갱신 (보통 같이 변하므로)
-    if (ANovaPlayerState* PS = GetOwningPlayerState<ANovaPlayerState>())
-    {
-        SetResourceText(Text_UnitWatt, PS->GetTotalUnitWatt(), PS->GetMaxUnitWatt());
-        if (ProgressBar_UnitWatt && PS->GetMaxUnitWatt() > 0)
-            ProgressBar_UnitWatt->SetPercent(PS->GetTotalUnitWatt() / PS->GetMaxUnitWatt());
-    }
+void UNovaResourceWidget::UpdateUnitWattUI(float Current, float Max)
+{
+    if (ProgressBar_UnitWatt && Max > 0) ProgressBar_UnitWatt->SetPercent(Current / Max);
+    SetResourceText(Text_UnitWatt, Current, Max);
 }
 
 void UNovaResourceWidget::SetResourceText(UTextBlock* TargetText, float Current, float Max)

--- a/Source/NovaRevolution/UI/NovaResourceWidget.h
+++ b/Source/NovaRevolution/UI/NovaResourceWidget.h
@@ -53,6 +53,9 @@ protected:
 
 	UFUNCTION()
 	void UpdatePopulationUI(float Current, float Max);
+	
+	UFUNCTION()
+	void UpdateUnitWattUI(float Current, float Max);
 
 	// 공통 텍스트 포맷팅 함수 (예: "50 / 100")
 	void SetResourceText(class UTextBlock* TargetText, float Current, float Max);


### PR DESCRIPTION
﻿## 📝 작업 상세
### ✨ Feat (새로운 기능)
- NovaResourceComponent: StopResourceRegen() 기능 추가
- NovaInterfaces & PlayerState: OnTotalUnitWattChanged 델리게이트 및 접근자 추가

### 🐛 Fix (버그 수정)
**자원 시스템**
  - 기지 파괴 시 자원 재생 중단: NovaBase 파괴 시 NovaResourceComponent의 Regen GE를 제거하여 Watt/SP 충전 중단 로직 구현
  - 유닛 사망 시 자원 반환: 유닛 파괴 시 점유 중이던 Population(-1) 및 UnitWatt(-비용)를 PlayerState로 즉시 반납하도록 개선
  - UI 동기화 버그 수정: TotalUnitWatt 변경 델리게이트를 추가하고 위젯에 연동하여, 인구수 변동 시 와트 총합 UI가 한 박자 늦게 갱신되던 문제 해결
