### PR TITLE
[Fix] AI 행동 전환 시 쿨다운 무시 버그 수정

### DIFF
--- a/Source/NovaRevolution/Core/AI/NovaAIController.cpp
+++ b/Source/NovaRevolution/Core/AI/NovaAIController.cpp
@@ -13,6 +13,9 @@
 #include "Components/CapsuleComponent.h"
 #include "NovaNavigationFilter_Move.h"
 #include "Engine/OverlapResult.h"
+#include "AbilitySystemComponent.h"
+#include "GAS/NovaAttributeSet.h"
+#include "GAS/NovaGameplayTags.h"
 
 const FName ANovaAIController::TargetLocationKey(TEXT("TargetLocation"));
 const FName ANovaAIController::TargetActorKey(TEXT("TargetActor"));
@@ -516,6 +519,33 @@ void ANovaAIController::ActivateAbilityByTag(const FGameplayTag& AbilityTag, AAc
 {
 	APawn* MyPawn = GetPawn();
 	if (!MyPawn || !Target || !AbilityTag.IsValid()) return;
+
+	// 공격 어빌리티인 경우 통합 쿨다운(FireRate) 검사
+	if (AbilityTag.MatchesTag(NovaGameplayTags::Ability_Attack))
+	{
+		float CurrentTime = GetWorld()->GetTimeSeconds();
+		float CurrentAttackInterval = 1.0f; // 기본값
+		
+		if (ANovaUnit* MyUnit = Cast<ANovaUnit>(MyPawn))
+		{
+			if (UAbilitySystemComponent* ASC = MyUnit->GetAbilitySystemComponent())
+			{
+				float FireRateValue = ASC->GetNumericAttribute(UNovaAttributeSet::GetFireRateAttribute());
+				if (FireRateValue > 0.0f)
+				{
+					CurrentAttackInterval = FireRateValue / 100.0f;
+				}
+			}
+		}
+
+		if (CurrentTime - LastAttackTime < CurrentAttackInterval)
+		{
+			// 아직 쿨다운 중이므로 무시
+			return;
+		}
+
+		LastAttackTime = CurrentTime;
+	}
 
 	FGameplayEventData Payload;
 	Payload.Instigator = MyPawn;

--- a/Source/NovaRevolution/Core/AI/NovaAIController.h
+++ b/Source/NovaRevolution/Core/AI/NovaAIController.h
@@ -101,6 +101,9 @@ protected:
 	float BypassDistance = 250.f;
 
 private:
+	/** 마지막으로 공격 어빌리티를 사용한 시간 (통합 쿨다운 관리용) */
+	float LastAttackTime = 0.0f;
+
 	/** Stuck 감지용 누적 타이머 */
 	float StuckTimer = 0.0f;
 

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Attack.cpp
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Attack.cpp
@@ -121,25 +121,8 @@ void UNovaBTTask_Attack::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 					AIC->StopMovementOptimized();
 				}
 				
-				float CurrentTime = GetWorld()->GetTimeSeconds();
-				
-				// FireRate 연동
-				float CurrentAttackInterval = AttackInterval;
-				if (UAbilitySystemComponent* ASC = MyUnit->GetAbilitySystemComponent())
-				{
-					float FireRateValue = ASC->GetNumericAttribute(UNovaAttributeSet::GetFireRateAttribute());
-					if (FireRateValue > 0.0f)
-					{
-						CurrentAttackInterval = FireRateValue / 100.0f;
-					}
-				}
-
-				// 공격 어빌리티 발동
-				if (CurrentTime - LastAttackTime >= CurrentAttackInterval)
-				{
-					AIC->ActivateAbilityByTag(AbilityTag, Target);
-					LastAttackTime = CurrentTime;
-				}
+				// 쿨다운 검사는 AIController 내부에서 통합 처리함
+				AIC->ActivateAbilityByTag(AbilityTag, Target);
 			}
 			
 			// 타겟의 사망 여부를 확인하고 죽었다면 Task를 즉시 성공시킵니다.

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Attack.h
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Attack.h
@@ -36,17 +36,11 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	FBlackboardKeySelector CommandTypeKey;
 
-	/** 공격 시도 간격 (초) */
-	UPROPERTY(EditAnywhere, Category = "Nova|AI")
-	float AttackInterval = 1.0f;
-
 	/** 공격 시 발동할 어빌리티 태그 */
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	FGameplayTag AbilityTag;
 
 private:
-	/** 마지막 공격 시간 */
-	float LastAttackTime = 0.0f;
 
 	/** 유닛의 공격 사거리를 가져옵니다. */
 	float GetAttackRange(class ANovaUnit* Unit) const;

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Hold.cpp
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Hold.cpp
@@ -84,27 +84,11 @@ void UNovaBTTask_Hold::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* NodeMe
 				return;
 			}
 
-			float CurrentTime = GetWorld()->GetTimeSeconds();
-
-				// FireRate 연동
-				float CurrentAttackInterval = AttackInterval;
-				if (UAbilitySystemComponent* ASC = MyUnit->GetAbilitySystemComponent())
-				{
-					float FireRateValue = ASC->GetNumericAttribute(UNovaAttributeSet::GetFireRateAttribute());
-					if (FireRateValue > 0.0f)
-					{
-						CurrentAttackInterval = FireRateValue / 100.0f;
-					}
-				}
-
-				if (CurrentTime - LastAttackTime >= CurrentAttackInterval)
-				{
-					AIC->ActivateAbilityByTag(AbilityTag, Target);
-					LastAttackTime = CurrentTime;
-				}
-			}
+			// 쿨다운 검사는 AIController 내부에서 통합 처리함
+			AIC->ActivateAbilityByTag(AbilityTag, Target);
 		}
 	}
+}
 
 float UNovaBTTask_Hold::GetAttackRange(ANovaUnit* Unit) const
 {

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Hold.h
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Hold.h
@@ -27,17 +27,11 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	FBlackboardKeySelector TargetActorKey;
 
-	/** 공격 시도 간격 (초) */
-	UPROPERTY(EditAnywhere, Category = "Nova|AI")
-	float AttackInterval = 1.0f;
-
 	/** 공격 시 발동할 어빌리티 태그 */
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	FGameplayTag AbilityTag;
 
 private:
-	/** 마지막 공격 시간 */
-	float LastAttackTime = 0.0f;
 
 	/** 유닛의 공격 사거리를 가져옵니다. */
 	float GetAttackRange(class ANovaUnit* Unit) const;

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Patrol.cpp
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Patrol.cpp
@@ -107,22 +107,8 @@ void UNovaBTTask_Patrol::TickTask(UBehaviorTreeComponent& OwnerComp, uint8* Node
 						AIC->StopMovementOptimized();
 					}
 					
-					float CurrentTime = GetWorld()->GetTimeSeconds();
-					float CurrentAttackInterval = AttackInterval;
-					if (UAbilitySystemComponent* ASC = MyUnit->GetAbilitySystemComponent())
-					{
-						float FireRateValue = ASC->GetNumericAttribute(UNovaAttributeSet::GetFireRateAttribute());
-						if (FireRateValue > 0.0f)
-						{
-							CurrentAttackInterval = FireRateValue / 100.0f;
-						}
-					}
-
-					if (CurrentTime - LastAttackTime >= CurrentAttackInterval)
-					{
-						AIC->ActivateAbilityByTag(AbilityTag, Target);
-						LastAttackTime = CurrentTime;
-					}
+					// 쿨다운 검사는 AIController 내부에서 통합 처리함
+					AIC->ActivateAbilityByTag(AbilityTag, Target);
 				}
 			}
 			else

--- a/Source/NovaRevolution/Core/AI/NovaBTTask_Patrol.h
+++ b/Source/NovaRevolution/Core/AI/NovaBTTask_Patrol.h
@@ -43,10 +43,6 @@ protected:
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	float ChaseDistanceLimit = 1000.0f;
 
-	/** 공격 간격 (초) */
-	UPROPERTY(EditAnywhere, Category = "Nova|AI")
-	float AttackInterval = 1.0f;
-
 	/** 공격 시 발동할 어빌리티 태그 */
 	UPROPERTY(EditAnywhere, Category = "Nova|AI")
 	FGameplayTag AbilityTag;
@@ -54,9 +50,6 @@ protected:
 private:
 	/** 현재 목표가 Origin인지 TargetLocation인지 여부 */
 	bool bMovingToOrigin = false;
-
-	/** 마지막 공격 시간 */
-	float LastAttackTime = 0.0f;
 
 	/** 교전이 시작된 지점 (Leash 기준점) */
 	FVector CombatOrigin = FVector::ZeroVector;


### PR DESCRIPTION
## 📌 작업 개요
- AI 컨트롤러 및 비헤이비어 트리(BT) 명령 태스크 간의 `LastAttackTime` 파편화로 인해 발생하던 공격 쿨다운 무시(즉발 연사) 버그 완벽 수정

## 📝 작업 상세
### 🐛 Fix (버그 수정)
**단일 AI 유닛 제어 및 쿨다운 구조 리팩토링**
  - `NovaAIController`
     - `ActivateAbilityByTag` 함수 내부에 유닛의 `FireRate` 기반으로 공격 쿨다운 인터벌을 직접 계산하고 검사하는 중앙 방어선(Gateway) 로직 신설
     - AI가 어떤 행동 노드에 있든 공유하는 전역 `LastAttackTime` 상태 변수 추가
  - `NovaBTTask_Attack`, `NovaBTTask_Hold`, `NovaBTTask_Patrol`
    - 각 행동 노드 파일 내부에 개별적으로 선언되어 있어, 노드가 전환될 때마다 타이머가 `0.0f`로 새롭게 갱신되어 쿨다운을 우회하게 하던 `AttackInterval` 및 `LastAttackTime` 중복 추적 로직 제거
