### PR TITLE
Fix: 안개 시스템 기반 타겟팅 버그 수정 및 가시성 로직 최적화

### DIFF
--- a/Source/NovaRevolution/Core/AI/NovaBTService_FindTarget.cpp
+++ b/Source/NovaRevolution/Core/AI/NovaBTService_FindTarget.cpp
@@ -34,6 +34,14 @@ void UNovaBTService_FindTarget::TickNode(UBehaviorTreeComponent& OwnerComp, uint
 	uint8 CommandTypeValue = BB->GetValueAsEnum(CommandTypeKey.SelectedKeyName);
 	ECommandType CurrentCommand = static_cast<ECommandType>(CommandTypeValue);
 
+	APawn* ControllingPawn = OwnerComp.GetAIOwner()->GetPawn();
+	if (!ControllingPawn) return;
+
+	ANovaUnit* MyUnit = Cast<ANovaUnit>(ControllingPawn);
+	if (!MyUnit) return;
+
+	int32 MyTeamID = MyUnit->GetTeamID();
+
 	// 기존 타겟 가시성 및 유효성 검사
 	AActor* CurrentTargetActor = Cast<AActor>(BB->GetValueAsObject(TargetActorKey.SelectedKeyName));
 	if (CurrentTargetActor)
@@ -41,7 +49,8 @@ void UNovaBTService_FindTarget::TickNode(UBehaviorTreeComponent& OwnerComp, uint
 		ANovaUnit* TargetUnit = Cast<ANovaUnit>(CurrentTargetActor);
 		
 		// 보이지 않거나 사망한 경우 타겟 해제
-		if (TargetUnit && (!TargetUnit->GetFogVisibility() || TargetUnit->IsDead()))
+		// [수정 전] if (TargetUnit && (!TargetUnit->GetFogVisibility() || TargetUnit->IsDead()))
+		if (TargetUnit && (!TargetUnit->IsVisibleToTeam(MyTeamID) || TargetUnit->IsDead()))
 		{
 			BB->ClearValue(TargetActorKey.SelectedKeyName);
 			CurrentTargetActor = nullptr;
@@ -68,12 +77,6 @@ void UNovaBTService_FindTarget::TickNode(UBehaviorTreeComponent& OwnerComp, uint
 	{
 		return;
 	}
-
-	APawn* ControllingPawn = OwnerComp.GetAIOwner()->GetPawn();
-	if (!ControllingPawn) return;
-
-	ANovaUnit* MyUnit = Cast<ANovaUnit>(ControllingPawn);
-	if (!MyUnit) return;
 
 	// 1. 탐색 범위 결정: 시야(Sight)와 사거리(Range) 중 더 큰 값 사용
 	float FinalSearchRadius = 1000.0f; // 기본값
@@ -112,7 +115,6 @@ void UNovaBTService_FindTarget::TickNode(UBehaviorTreeComponent& OwnerComp, uint
 
 	if (bHit)
 	{
-		int32 MyTeamID = MyUnit->GetTeamID();
 		ENovaTargetType MyWeaponTargetType = MyUnit->GetTargetType();
 		
 		UAbilitySystemComponent* MyASC = MyUnit->GetAbilitySystemComponent();
@@ -169,11 +171,13 @@ void UNovaBTService_FindTarget::TickNode(UBehaviorTreeComponent& OwnerComp, uint
 			bool bIsVisible = true;
 			if (TargetUnit)
 			{
-				bIsVisible = TargetUnit->GetFogVisibility();
+				// [수정 전] bIsVisible = TargetUnit->GetFogVisibility();
+				bIsVisible = TargetUnit->IsVisibleToTeam(MyTeamID);
 			}
 			else if (ANovaBase* TargetBase = Cast<ANovaBase>(PotentialTarget))
 			{
-				bIsVisible = TargetBase->GetFogVisibility();
+				// [수정 전] bIsVisible = TargetBase->GetFogVisibility();
+				bIsVisible = TargetBase->IsVisibleToTeam(MyTeamID);
 			}
 
 			if (!bIsVisible) continue;

--- a/Source/NovaRevolution/Core/NovaBase.cpp
+++ b/Source/NovaRevolution/Core/NovaBase.cpp
@@ -138,6 +138,12 @@ void ANovaBase::BeginPlay()
 	{
 		HighlightDynamicMaterial = UMaterialInstanceDynamic::Create(HighlightMasterMaterial, this);
 	}
+	
+	// 자신의 팀 ID에 비트마스크를 미리 켜둠 (기지는 항상 자기 팀에게 보임)
+	if (TeamID >= 0 && TeamID < 32)
+	{
+		SetVisibilityForTeam(TeamID, true);
+	}
 }
 
 void ANovaBase::Tick(float DeltaTime)
@@ -443,6 +449,14 @@ void ANovaBase::SetFogVisibility(bool bVisible)
 	if (bIsVisibleByFog == bVisible) return;
 	bIsVisibleByFog = bVisible;
 
+	// 로컬 플레이어 팀 ID 가져오기
+	int32 LocalTeamID = -1;
+	if (auto* PC = GetWorld()->GetFirstPlayerController()) {
+		if (auto* PS = PC->GetPlayerState<ANovaPlayerState>()) LocalTeamID = PS->GetTeamID();
+	}
+	// 로컬 플레이어에 대한 비트마스크도 함께 업데이트 (데이터 d일관성)
+	SetVisibilityForTeam(LocalTeamID, bVisible);
+	
 	// 시각적 처리 (건물 메시 숨김)
 	SetActorHiddenInGame(!bVisible);
 
@@ -560,4 +574,24 @@ void ANovaBase::NotifyActorBeginCursorOver()
 void ANovaBase::NotifyActorEndCursorOver()
 {
 	SetHighlightStatus(ENovaHighlightPriority::Hover, false);
+}
+
+bool ANovaBase::IsVisibleToTeam(int32 CurrentTeamID) const
+{
+	// 1. 유효하지 않은 팀 ID(-1 등)인 경우 처리
+	if (CurrentTeamID < 0 || CurrentTeamID >= 32)
+	{
+		return false;
+	}
+
+	// 2. 유효한 경우에만 비트 연산 수행
+	return (VisibilityMask & (1 << CurrentTeamID)) != 0;
+}
+
+void ANovaBase::SetVisibilityForTeam(int32 CurrentTeamID, bool bVisible)
+{
+	if (CurrentTeamID < 0 || CurrentTeamID >= 32) return;
+
+	if (bVisible) VisibilityMask |= (1 << CurrentTeamID);
+	else VisibilityMask &= ~(1 << CurrentTeamID);
 }

--- a/Source/NovaRevolution/Core/NovaBase.h
+++ b/Source/NovaRevolution/Core/NovaBase.h
@@ -190,4 +190,16 @@ private:
 	bool bIsDragHighlighted = false;
 	bool bIsSkillHighlighted = false;
 	FLinearColor SkillHighlightColor = FLinearColor::White;
+	
+public:
+	/** 특정 팀에게 이 유닛이 보이는지 확인 (비트 연산) */
+	UFUNCTION(BlueprintPure, Category = "Nova|Fog")
+	bool IsVisibleToTeam(int32 CurrentTeamID) const;
+
+	/** 특정 팀에 대한 가시성 상태를 업데이트 (비트 연산) */
+	void SetVisibilityForTeam(int32 CurrentTeamID, bool bVisible);
+
+private:
+	/** 팀별 가시성 비트마스크 (0번 비트: 팀 0, 1번 비트: 팀 1 ...) */
+	uint32 VisibilityMask = 0;
 };

--- a/Source/NovaRevolution/Core/NovaFogManager.cpp
+++ b/Source/NovaRevolution/Core/NovaFogManager.cpp
@@ -13,6 +13,7 @@
 #include "NovaRevolution.h"
 #include "NovaUnit.h"
 #include "Components/BoxComponent.h"
+#include "GameFramework/GameStateBase.h"
 #include "GAS/NovaAttributeSet.h"
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetMaterialLibrary.h"
@@ -59,142 +60,159 @@ void ANovaFogManager::UpdateFog()
 {
 	if (!CurrentFogRT || !HistoryFogRT || !MapManager) return;
 
-	UKismetRenderingLibrary::ClearRenderTarget2D(GetWorld(), CurrentFogRT, FLinearColor::Black);
-
-	// 1. Standalone 안전장치: 첫 번째 유효한 프레임에 초기화 수행
-	if (!bIsFogInitialized)
-	{
-		// History를 White로 확실히 밀어줌
-		UKismetRenderingLibrary::ClearRenderTarget2D(GetWorld(), HistoryFogRT, FLinearColor::White);
-
-		// MPC 파라미터도 이때 확실히 업데이트
-		UpdateMPCParameters();
-
-		bIsFogInitialized = true;
-	}
-
 	// 로컬 플레이어 정보 가져오기
 	APlayerController* PC = GetWorld()->GetFirstPlayerController();
 	if (!PC) return;
-	ANovaPlayerState* PS = PC ? PC->GetPlayerState<ANovaPlayerState>() : nullptr;
+	ANovaPlayerState* PS = PC->GetPlayerState<ANovaPlayerState>();
 	if (!PS)
 	{
 		UE_LOG(LogTemp, Warning, TEXT("FogManager: PlayerState is NULL!"));
 		return;
 	}
 
-	// INovaTeamInterface를 통해 플레이어의 팀 확인
-	int32 PlayerTeamID = PS->GetTeamID();
-
-	// --- [최적화 적용] 등록된 액터 리스트 사용 ---
-	const TArray<TWeakObjectPtr<AActor>>& RegisteredActors = MapManager->GetRegisteredActors();;
-
-	// 시야 계산을 위한 임시 저장소
-	struct FSightSource
+	// 1. Standalone 안전장치: 첫 번째 유효한 프레임에 초기화 수행
+	if (!bIsFogInitialized)
 	{
-		FVector Location;
-		float RadiusSq; // 계산 최적화를 위해 반지름의 제곱 저장
-	};
-	TArray<FSightSource> FriendlySights;
-	TArray<AActor*> EnemyActors;
+		UKismetRenderingLibrary::ClearRenderTarget2D(GetWorld(), HistoryFogRT, FLinearColor::White);
+		UpdateMPCParameters();
+		bIsFogInitialized = true;
+	}
 
-	// --- 드로잉 준비 ---
-	FCanvas Canvas(CurrentFogRT->GameThread_GetRenderTargetResource(),
-	               nullptr,
-	               FGameTime::GetTimeSinceAppStart(),
-	               GetWorld()->GetFeatureLevel()
-	);
-
-	// 월드 너비 계산 방식 변경
+	// 2. 초기 설정 및 팀 정보 수집
+	int32 LocalPlayerTeamID = PS->GetTeamID();
+	const TArray<TWeakObjectPtr<AActor>>& RegisteredActors = MapManager->GetRegisteredActors();
 	FBox Bounds = MapManager->GetMapBounds();
 	float WorldWidth = Bounds.Max.X - Bounds.Min.X;
 
-	// --- 1차 순회 : 아군 시야 그리기 및 정보 수집 ---
+	TSet<int32> ActiveTeamSet;
+	ActiveTeamSet.Add(LocalPlayerTeamID);
+	if (AGameStateBase* GS = GetWorld()->GetGameState())
+	{
+		for (APlayerState* PlayerState : GS->PlayerArray)
+		{
+			if (INovaTeamInterface* TeamInterface = Cast<INovaTeamInterface>(PlayerState))
+			{
+				int32 TeamID = TeamInterface->GetTeamID();
+				if (TeamID >= 0 && TeamID < 32) ActiveTeamSet.Add(TeamID);
+			}
+		}
+	}
+
+	// --- [최적화] 1차 순회: 모든 액터를 한 번만 순회하며 팀별 시야 소스 분류 ---
+	struct FSightSource
+	{
+		FVector Location;
+		float RadiusSq;
+	};
+	// 팀 ID를 키로 하는 시야 소스 맵
+	TMap<int32, TArray<FSightSource>> TeamSightsMap;
+	// 가시성 판단 대상이 될 모든 유닛/기지 리스트
+	TArray<AActor*> AllSelectableActors;
+
 	for (const TWeakObjectPtr<AActor>& WeakActor : RegisteredActors)
 	{
 		AActor* Actor = WeakActor.Get();
-		// PlayerState에 의해 생긴 유령시야 해결 (INovaTeamInterface를 상속받았기 때문에 생긴 문제)
-		if (Actor->IsA<APlayerState>()) continue;
+		if (!Actor || Actor->IsA<APlayerState>()) continue;
 
 		INovaTeamInterface* TeamActor = Cast<INovaTeamInterface>(Actor);
-		if (!TeamActor) continue; // 팀 정보가 없는 액터는 무시
+		if (!TeamActor) continue;
 
-		if (TeamActor && TeamActor->GetTeamID() == PlayerTeamID)
+		AllSelectableActors.Add(Actor);
+		int32 ActorTeamID = TeamActor->GetTeamID();
+
+		// 이 액터가 시야를 제공할 수 있는지 확인 (ASC의 Sight 속성)
+		float SightRadius = 800.f;
+		if (IAbilitySystemInterface* ASCInterface = Cast<IAbilitySystemInterface>(Actor))
 		{
-			float SightRadius = 800.f; // 기본 시야 값
-			if (ANovaUnit* Unit = Cast<ANovaUnit>(Actor))
+			if (UAbilitySystemComponent* ASC = ASCInterface->GetAbilitySystemComponent())
 			{
-				if (Unit->GetAbilitySystemComponent())
-				{
-					SightRadius = Unit->GetAbilitySystemComponent()->GetNumericAttribute(
-						UNovaAttributeSet::GetSightAttribute());
-				}
-				// 아군 유닛은 항상 보이도록 설정
-				Unit->SetFogVisibility(true);
+				SightRadius = ASC->GetNumericAttribute(UNovaAttributeSet::GetSightAttribute());
 			}
-			else if (ANovaBase* Base = Cast<ANovaBase>(Actor))
-			{
-				// 기지의 시야 범위 설정
-				if (Base->GetAbilitySystemComponent())
-				{
-					SightRadius = Base->GetAbilitySystemComponent()->GetNumericAttribute(
-						UNovaAttributeSet::GetSightAttribute());
-				}
-				// 아군 기지는 항상 보이도록 설정
-				Base->SetFogVisibility(true);
-			}
-			// 시야 정보 저장 (나중에 적군 가시성 체크용)
-			FriendlySights.Add({Actor->GetActorLocation(), FMath::Square(SightRadius)});
-
-			// UV 좌표 계산
-			FVector2D UV = WorldToFogUV(Actor->GetActorLocation());
-
-			// 캔버스에서 크기 계산 (Box 전체 너비 대비 시야 지름의 비율)
-			float CanvasSize = (SightRadius * 2.0f / WorldWidth) * TextureResolution;
-
-			// 시야 원 그리기 (중앙 정렬을 위해 CanvasSize * 0.5f 차감)
-			FCanvasTileItem TileItem(UV * TextureResolution - (CanvasSize * 0.5f),
-			                         BrushMaterial ? BrushMaterial->GetRenderProxy() : nullptr,
-			                         FVector2D(CanvasSize, CanvasSize));
-
-			// 블렌딩 모드 설정 (시야 원들이 서로 겹치 떄 자연스럽게 합쳐짐)
-			TileItem.BlendMode = SE_BLEND_Additive;
-			Canvas.DrawItem(TileItem);
 		}
-		// 적군인 경우: 일단 리스트에 담아둠 (2차 순회에 한꺼번에 체크)
-		// else if (TeamActor->GetTeamID() != PlayerTeamID)
-		else
+
+		// 해당 팀의 시야 리스트에 추가
+		if (ActiveTeamSet.Contains(ActorTeamID))
 		{
-			EnemyActors.Add(Actor);
+			TeamSightsMap.FindOrAdd(ActorTeamID).Add({Actor->GetActorLocation(), FMath::Square(SightRadius)});
+
+			// 자기 팀 유닛은 해당 팀에게 항상 보이도록 비트마스크 미리 설정
+			if (ANovaUnit* Unit = Cast<ANovaUnit>(Actor)) Unit->SetVisibilityForTeam(ActorTeamID, true);
+			else if (ANovaBase* Base = Cast<ANovaBase>(Actor)) Base->SetVisibilityForTeam(ActorTeamID, true);
 		}
 	}
-	Canvas.Flush_GameThread();
 
-	// --- 2차 순회: 적군 유닛 가시성 판단 (O(N*M)) ---
-	for (AActor* Enemy : EnemyActors)
+	// --- 2차 순회: 각 팀별 가시성 판단 및 렌더링 ---
+	for (int32 CurrentTeamID : ActiveTeamSet)
 	{
-		bool bIsVisible = false;
-		FVector EnemyLoc = Enemy->GetActorLocation();
+		bool bIsLocalPlayerTeam = (CurrentTeamID == LocalPlayerTeamID);
+		const TArray<FSightSource>* CurrentTeamSights = TeamSightsMap.Find(CurrentTeamID);
 
-		// 모든 아군 시야 범위와 비교
-		for (const auto& Sight : FriendlySights)
+		// 3. 로컬 플레이어 팀인 경우에만 렌더 타겟 그리기 (시각적 안개)
+		if (bIsLocalPlayerTeam)
 		{
-			// Z값을 무시하도록 수정
-			if (FVector::DistSquared2D(EnemyLoc, Sight.Location) < Sight.RadiusSq)
+			UKismetRenderingLibrary::ClearRenderTarget2D(GetWorld(), CurrentFogRT, FLinearColor::Black);
+			FCanvas Canvas(CurrentFogRT->GameThread_GetRenderTargetResource(), nullptr, FGameTime::GetTimeSinceAppStart(), GetWorld()->GetFeatureLevel());
+
+			if (CurrentTeamSights)
 			{
-				bIsVisible = true;
-				break; // 하나라도 겹치면 더 볼 필요 없음
+				for (const auto& Sight : *CurrentTeamSights)
+				{
+					FVector2D UV = WorldToFogUV(Sight.Location);
+					float Radius = FMath::Sqrt(Sight.RadiusSq);
+					float CanvasSize = (Radius * 2.0f / WorldWidth) * TextureResolution;
+
+					FCanvasTileItem TileItem(UV * TextureResolution - (CanvasSize * 0.5f),
+					                         BrushMaterial ? BrushMaterial->GetRenderProxy() : nullptr,
+					                         FVector2D(CanvasSize, CanvasSize));
+					TileItem.BlendMode = SE_BLEND_Additive;
+					Canvas.DrawItem(TileItem);
+				}
 			}
+			Canvas.Flush_GameThread();
 		}
-		
-		// 적군 유닛/기지 가시성 상태 업데이트
-		if (ANovaUnit* Unit = Cast<ANovaUnit>(Enemy))
+
+		// 4. 모든 대상 액터들에 대해 현재 팀(CurrentTeamID)의 가시성 판단
+		for (AActor* TargetActor : AllSelectableActors)
 		{
-			Unit->SetFogVisibility(bIsVisible);
-		}
-		else if (ANovaBase* Base = Cast<ANovaBase>(Enemy))
-		{
-			Base->SetFogVisibility(bIsVisible);
+			INovaTeamInterface* TargetTeam = Cast<INovaTeamInterface>(TargetActor);
+			if (!TargetTeam) continue;
+
+			// 자기 팀 유닛은 이미 위에서 처리했으므로 건너뜀 (최적화)
+			if (TargetTeam->GetTeamID() == CurrentTeamID)
+			{
+				if (bIsLocalPlayerTeam)
+				{
+					if (ANovaUnit* Unit = Cast<ANovaUnit>(TargetActor)) Unit->SetFogVisibility(true);
+					else if (ANovaBase* Base = Cast<ANovaBase>(TargetActor)) Base->SetFogVisibility(true);
+				}
+				continue;
+			}
+
+			bool bVisible = false;
+			if (CurrentTeamSights)
+			{
+				FVector TargetLoc = TargetActor->GetActorLocation();
+				for (const auto& Sight : *CurrentTeamSights)
+				{
+					if (FVector::DistSquared2D(TargetLoc, Sight.Location) < Sight.RadiusSq)
+					{
+						bVisible = true;
+						break;
+					}
+				}
+			}
+
+			// 비트마스크 업데이트 (AI 판단용)
+			if (ANovaUnit* Unit = Cast<ANovaUnit>(TargetActor))
+			{
+				Unit->SetVisibilityForTeam(CurrentTeamID, bVisible);
+				if (bIsLocalPlayerTeam) Unit->SetFogVisibility(bVisible);
+			}
+			else if (ANovaBase* Base = Cast<ANovaBase>(TargetActor))
+			{
+				Base->SetVisibilityForTeam(CurrentTeamID, bVisible);
+				if (bIsLocalPlayerTeam) Base->SetFogVisibility(bVisible);
+			}
 		}
 	}
 }

--- a/Source/NovaRevolution/Core/NovaUnit.cpp
+++ b/Source/NovaRevolution/Core/NovaUnit.cpp
@@ -1333,7 +1333,7 @@ float ANovaUnit::GetRequiredRetreatDistance(const AActor* Target) const
 	}
 
 	float AdjustedMinRange = MinRange + TargetRadius;
-	
+
 	// 부족한 후퇴 거리 계산 (값이 양수이면 물러나야 함)
 	return FMath::Max(0.0f, AdjustedMinRange - DistXY);
 }
@@ -1362,7 +1362,7 @@ void ANovaUnit::PushUnit(FVector PushDir, float PushAmount, int32 Depth)
 			{
 				TargetLoc = HitLocation;
 			}
-			
+
 			// 내비메시 표면에 Z 고도 고정 (지상/공중 통합 처리)
 			FNavLocation ProjectedLoc;
 			if (NavSys->ProjectPointToNavigation(TargetLoc, ProjectedLoc, FVector(10.f, 10.f, 200.f), NavData))
@@ -1370,7 +1370,7 @@ void ANovaUnit::PushUnit(FVector PushDir, float PushAmount, int32 Depth)
 				TargetLoc = ProjectedLoc.Location;
 				TargetLoc.Z += GetCapsuleComponent()->GetScaledCapsuleHalfHeight();
 			}
-			
+
 			DesiredOffset = TargetLoc - CurrentLoc;
 		}
 	}
@@ -1645,6 +1645,26 @@ void ANovaUnit::UpdateHealthBar()
 #pragma endregion
 
 #pragma region Navigation & Fog of War
+bool ANovaUnit::IsVisibleToTeam(int32 CurrentTeamID) const
+{
+	// 1. 유효하지 않은 팀 ID(-1 등)인 경우 처리
+	if (CurrentTeamID < 0 || CurrentTeamID >= 32)
+	{
+		return false;
+	}
+
+	// 2. 유효한 경우에만 비트 연산 수행
+	return (VisibilityMask & (1 << CurrentTeamID)) != 0;
+}
+
+void ANovaUnit::SetVisibilityForTeam(int32 CurrentTeamID, bool bVisible)
+{
+	if (CurrentTeamID < 0 || CurrentTeamID >= 32) return;
+
+	if (bVisible) VisibilityMask |= (1 << CurrentTeamID);
+	else VisibilityMask &= ~(1 << CurrentTeamID);
+}
+
 void ANovaUnit::SetFogVisibility(bool bVisible)
 {
 	if (bIsVisibleByFog == bVisible) return;
@@ -1783,7 +1803,7 @@ void ANovaUnit::OnSpawnFromPool_Implementation()
 		if (MovementType == ENovaMovementType::Ground)
 		{
 			MoveComp->bConstrainToPlane = false; // [수정] 경사로 진입을 위해 제약 해제
-			
+
 			// 현재 위치를 내비메시 바닥으로 강제 스냅하여 "살짝 뜨는" 현상 방지
 			UNavigationSystemV1* NavSys = FNavigationSystem::GetCurrent<UNavigationSystemV1>(GetWorld());
 			UCapsuleComponent* Capsule = GetCapsuleComponent();
@@ -1840,6 +1860,7 @@ void ANovaUnit::OnSpawnFromPool_Implementation()
 	// 6. UI 상태 최종 초기화
 	// [핵심] bIsVisibleByFog를 반대값으로 설정하여 SetFogVisibility(true)가 반드시 실행되도록 강제합니다.
 	bIsVisibleByFog = false;
+	VisibilityMask = 0; // 추가: 가시성 비트마스크 초기화
 	SetFogVisibility(true);
 
 	UpdateHealthBar();
@@ -1911,7 +1932,8 @@ void ANovaUnit::OnReturnToPool_Implementation()
 
 	// 다음 사용 시 SetFogVisibility가 정상 작동하도록 초기값(true)으로 리셋
 	bIsVisibleByFog = true;
-
+	VisibilityMask = 0; // 추가: 가시성 비트마스크 초기화
+	
 	// 5. 조립 데이터 및 파츠 액터 초기화 (풀로 반환)
 	UNovaObjectPoolSubsystem* PoolSubsystem = GetWorld()->GetSubsystem<UNovaObjectPoolSubsystem>();
 	if (PoolSubsystem)
@@ -1939,14 +1961,14 @@ void ANovaUnit::OnReturnToPool_Implementation()
 		// 모든 활성 GameplayEffect 제거 (루프를 통해 확실하게 제거)
 		const FActiveGameplayEffectsContainer& ActiveGEs = AbilitySystemComponent->GetActiveGameplayEffects();
 		TArray<FActiveGameplayEffectHandle> AllHandles = ActiveGEs.GetAllActiveEffectHandles();
-		
+
 		for (const FActiveGameplayEffectHandle& Handle : AllHandles)
 		{
 			AbilitySystemComponent->RemoveActiveGameplayEffect(Handle);
 		}
-		
+
 		// NOVA_LOG(Log, "GAS State Cleared for %s (Removed %d GEs)", *GetName(), AllHandles.Num());
-		
+
 		// 모든 어빌리티 및 큐 제거
 		AbilitySystemComponent->ClearAllAbilities();
 		AbilitySystemComponent->RemoveAllGameplayCues();

--- a/Source/NovaRevolution/Core/NovaUnit.h
+++ b/Source/NovaRevolution/Core/NovaUnit.h
@@ -350,7 +350,7 @@ public:
 
 	// PortraitCapture Getter(PlayerController에게 권한 위임)
 	TObjectPtr<USceneCaptureComponent2D> GetPortraitCapture() const { return PortraitCapture; }
-	
+
 protected:
 	// --- 마우스 오버 이벤트(하이라이트 처리) ---
 	virtual void NotifyActorBeginCursorOver() override;
@@ -412,13 +412,24 @@ private:
 
 #pragma region Navigation & Fog of War
 
+private:
+	/** 팀별 가시성 비트마스크 (0번 비트: 팀 0, 1번 비트: 팀 1 ...) */
+	uint32 VisibilityMask = 0; // unint32: 부호 없는 32비트 정수
+
 public:
+	/** 특정 팀에게 이 유닛이 보이는지 확인 (비트 연산) */
+	UFUNCTION(BlueprintPure, Category = "Nova|Fog")
+	bool IsVisibleToTeam(int32 CurrentTeamID) const;
+
+	/** 특정 팀에 대한 가시성 상태를 업데이트 (비트 연산) */
+	void SetVisibilityForTeam(int32 CurrentTeamID, bool bVisible);
+
 	// --- INovaTeamInterface ---
 	virtual int32 GetTeamID() const override { return TeamID; }
 
 	// 안개 가시성 설정 함수
 	void SetFogVisibility(bool bVisible);
-	
+
 	bool GetFogVisibility() const { return bIsVisibleByFog; }
 
 	/** 유닛이 NavMesh 상에서 장애물로 작동할지 여부를 설정합니다. */

--- a/Source/NovaRevolution/Player/NovaPlayerController.cpp
+++ b/Source/NovaRevolution/Player/NovaPlayerController.cpp
@@ -347,40 +347,8 @@ void ANovaPlayerController::Input_AbilityInputTagPressed(FGameplayTag InputTag)
 		// 선택 대상이 존재할 때
 		else if (SelectedActors.Num() > 0)
 		{
-			// 로컬 플레이어의 팀 ID 가져오기 (적군 판별용)
-			int32 LocalTeamID = -1;
-			if (ANovaPlayerState* PS = GetPlayerState<ANovaPlayerState>())
-			{
-				LocalTeamID = PS->GetTeamID();
-			}
 			FCommandData CmdData;
-			CmdData.CommandType = ECommandType::Move;
-			CmdData.TargetLocation = CursorHit.Location;
-
-			AActor* HitActor = CursorHit.GetActor();
-			if (HitActor)
-			{
-				// 인터페이스 캐스팅
-				INovaSelectableInterface* Selectable = Cast<INovaSelectableInterface>(HitActor);
-				INovaTeamInterface* TeamInterface = Cast<INovaTeamInterface>(HitActor);
-
-				// 대상이 선택 가능함
-				if (Selectable && Selectable->IsSelectable())
-				{
-					// 타겟 정보 전달
-					CmdData.TargetActor = HitActor;
-					// 적대적 타겟 선택 시 공격 명령 전달
-					if (TeamInterface && !TeamInterface->IsFriendly(LocalTeamID))
-					{
-						CmdData.CommandType = ECommandType::Attack;
-					}
-				}
-				else
-				{
-					// 지형이나 일반 오브젝트인 경우 Actor는 무시하고 위치만 전달
-					CmdData.TargetActor = nullptr;
-				}
-			}
+			DetermineCommandTarget(CursorHit, ECommandType::Move, CmdData);
 
 			// 선택된 유닛들에게 명령 전달
 			IssueCommandToSelectedUnits(CmdData);
@@ -507,23 +475,7 @@ void ANovaPlayerController::Input_AbilityInputTagReleased(FGameplayTag InputTag)
 			GetCursorHitResult(CursorHit);
 
 			FCommandData CmdData;
-			CmdData.CommandType = PendingCommandType;
-			CmdData.TargetLocation = CursorHit.Location;
-
-			// TargetActor가 실제로 유닛(Unit)이나 기지(Base)인지 검사
-			AActor* HitActor = CursorHit.GetActor();
-			if (HitActor)
-			{
-				// 인터페이스를 가지고 있거나 특정 클래스(Unit/Base)인 경우메만 TargetActor로 인정
-				if (HitActor->GetClass()->ImplementsInterface(UNovaSelectableInterface::StaticClass()))
-				{
-					CmdData.TargetActor = HitActor;
-				}
-				else
-				{
-					CmdData.TargetActor = nullptr;
-				}
-			}
+			DetermineCommandTarget(CursorHit, PendingCommandType, CmdData);
 
 			IssueCommandToSelectedUnits(CmdData);
 
@@ -1178,5 +1130,47 @@ void ANovaPlayerController::SetCameraLocation(const FVector& TargetWorldPos)
 		NewLocation.Z = ControlledPawn->GetActorLocation().Z;
 
 		ControlledPawn->SetActorLocation(NewLocation);
+	}
+}
+
+void ANovaPlayerController::DetermineCommandTarget(const FHitResult& HitResult, ECommandType InCommandType,
+                                                   FCommandData& OutCmdData)
+{
+	// 기본값 설정
+	OutCmdData.CommandType = InCommandType;
+	OutCmdData.TargetLocation = HitResult.Location;
+	OutCmdData.TargetActor = nullptr;
+
+	AActor* HitActor = HitResult.GetActor();
+	if (!HitActor) return;
+
+	// 인터페이스 캐스팅
+	INovaSelectableInterface* Selectable = Cast<INovaSelectableInterface>(HitActor);
+	INovaTeamInterface* TeamInterface = Cast<INovaTeamInterface>(HitActor);
+
+	if (Selectable)
+	{
+		// 로컬 플레이어 팀 ID 확인
+		int32 LocalTeamID = -1;
+		if (ANovaPlayerState* PS = GetPlayerState<ANovaPlayerState>())
+		{
+			LocalTeamID = PS->GetTeamID();
+		}
+
+		bool bIsFriendly = TeamInterface && TeamInterface->GetTeamID() == LocalTeamID;
+		// [버그 수정의 핵심] 안개 속 적(IsSelectable == false)은 타겟팅 대상에서 제외
+		bool bIsVisible = Selectable->IsSelectable();
+
+		// 시야에 보이는 경우에만 타겟으로 인정
+		if (bIsVisible)
+		{
+			OutCmdData.TargetActor = HitActor;
+
+			// 스마트 명령 처리: 우클릭(Move) 시 적군을 찍었다면 자동으로 Attack으로 전환
+			if (InCommandType == ECommandType::Move && !bIsFriendly)
+			{
+				OutCmdData.CommandType = ECommandType::Attack;
+			}
+		}
 	}
 }

--- a/Source/NovaRevolution/Player/NovaPlayerController.h
+++ b/Source/NovaRevolution/Player/NovaPlayerController.h
@@ -145,6 +145,12 @@ protected:
 	// 드래그 선택을 수행하는 실제 판정 함수
 	void PerformBoxSelection();
 
+	/** 
+	 * 마우스 히트 결과와 현재 명령 타입을 기반으로 
+	 * 실제 유효한 타겟 액터와 위치를 결정하는 통합 로직
+	 */
+	void DetermineCommandTarget(const FHitResult& HitResult, ECommandType InCommandType, FCommandData& OutCmdData);
+
 	// 선택된 유닛들에게 실제 명령을 하달하는 헬퍼 함수
 	void IssueCommandToSelectedUnits(const FCommandData& CommandData);
 


### PR DESCRIPTION
## 📌 작업 개요
- 이슈: 안개(Fog of War) 시스템과 관련된 타겟팅 버그 수정 및 AI 시야 로직 개선
- 목적: 플레이어의 부적절한 타겟팅 방지 및 적 AI가 안개를 무시하고 공격하는 문제 해결

## 📝 작업 상세
### ✨ Feat (새로운 기능)
**Core / Fog of War**
  - 팀별 가시성 비트마스크(Visibility Bitmask) 도입
    - ANovaUnit, ANovaBase에 uint32 VisibilityMask를 추가하여 최대 32개 팀까지 개별 가시성 상태를 저장 가능하도록 구현
    - IsVisibleToTeam(int32 TeamID), SetVisibilityForTeam 함수를 통해 팀별 시야 판정 표준화
  
### 🐛 Fix (버그 수정)
**Player / Targeting**
  - 안개 속 적 타겟팅 방지
    - ANovaPlayerController에 DetermineCommandTarget 통합 로직을 추가하여 우클릭 및 단축키 명령 시 안개 밖 적만 타겟으로 지정되도록 수정

**AI / Perception**
  - 적 AI 안개 무시 버그 수정
    - BTService_FindTarget이 로컬 플레이어의 시야가 아닌, AI 자신의 팀 시야(비트마스크)를 참조하여 타겟을 선정하도록 수정

### ♻️ Refactor (코드 리팩토링)
**Core / FogManager**
  - UpdateFog 로직 최적화
    - 팀별로 반복 순회하던 로직을 단일 액터 순회($O(Actors)$)로 개선하여 성능 향상
    - GameState를 통해 활성 팀 ID를 동적으로 수집하도록 수정하여 확장성 확보

### 🔧 Chore (빌드, 설정 등 기타)
**Core / Object Pooling**
  - 가시성 데이터 초기화
    - 유닛이 오브젝트 풀에서 재사용(OnSpawnFromPool)되거나 반납(OnReturnToPool)될 때 가시성 마스크를 초기화하여 데이터 오염 방지